### PR TITLE
Publish bootstrap-timepicker 0.2.2 webjar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>0.2.1</upstream.version>
+        <upstream.version>0.2.2</upstream.version>
         <upstream.url>https://github.com/jdewit/bootstrap-timepicker/archive</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destDir>
     </properties>


### PR DESCRIPTION
Also update bootstrap version to latest.

I can pull another changeset to the latest bootstrap-timepicker tagged version (0.2.3), if this request seems OK for you, and after you release this one.
