### PR TITLE
Update bootstrap-timepicker version to 0.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>bootstrap-timepicker</artifactId>
-    <version>0.2.2-SNAPSHOT</version>
+    <version>0.2.3-SNAPSHOT</version>
     <name>Bootstrap Timepicker</name>
     <description>WebJar for Bootstrap Timepicker</description>
     <url>http://webjars.org</url>
@@ -49,7 +49,7 @@
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>0.2.2</upstream.version>
+        <upstream.version>0.2.3</upstream.version>
         <upstream.url>https://github.com/jdewit/bootstrap-timepicker/archive</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destDir>
     </properties>


### PR DESCRIPTION
Latest bootstrap-timepicker tagged version (0.2.3), but project seems to be idle.
